### PR TITLE
Fixed requests_get_timeout and added schemata fields.

### DIFF
--- a/ibflex/client.py
+++ b/ibflex/client.py
@@ -71,7 +71,7 @@ ResponseSchemata = {'Success': ResponseSuccessSchema,
                     'Fail': ResponseFailureSchema}
 
 
-def requests_get_timeout(url):
+def requests_get_timeout(url, token, query_id):
     response = None
     req_count = 1
     while(not response):
@@ -92,7 +92,7 @@ def requests_get_timeout(url):
 
 def send_request(token, query_id, url=None):
     url = url or REQUEST_URL
-    response = requests_get_timeout(url)
+    response = requests_get_timeout(url, token, query_id)
     response = ET.fromstring(response.content)
     assert response.tag == 'FlexStatementResponse'
     timestamp = response.attrib['timestamp']
@@ -113,7 +113,7 @@ def send_request(token, query_id, url=None):
 
 def get_statement(token, reference_code, url=None):
     url = url or STMT_URL
-    statement = requests_get_timeout(url)
+    statement = requests_get_timeout(url, token, reference_code)
     return statement.content
 
 

--- a/ibflex/schemata.py
+++ b/ibflex/schemata.py
@@ -544,8 +544,14 @@ class TradeConfirmation(Schema, TradeMixin):
     orderType = OneOf("LMT", "MKT", "MOC")
     traderID = String()
     isAPIOrder = Boolean()
+    code = List()
+    tax = Decimal()
+    listingExchange = String()
+    underlyingListingExchange = String()
+    settleDate = String()
+    underlyingSecurityID = String()
 
-
+    
 class OptionEAE(Schema, AccountMixin, CurrencyMixin, SecurityMixin):
     """
     Option Exercise, Assignment, or Expiration

--- a/ibflex/schemata.py
+++ b/ibflex/schemata.py
@@ -249,14 +249,19 @@ class EquitySummaryByReportDateInBase(Schema, AccountMixin):
     fdicInsuredBankSweepAccount = Decimal()
     fdicInsuredBankSweepAccountLong = Decimal()
     fdicInsuredBankSweepAccountShort = Decimal()
+    fdicInsuredBankSweepAccountCashComponent = Decimal()
     fdicInsuredAccountInterestAccruals = Decimal()
     fdicInsuredAccountInterestAccrualsLong = Decimal()
     fdicInsuredAccountInterestAccrualsShort = Decimal()
+    fdicInsuredAccountInterestAccrualsComponent = Decimal()
     total = Decimal()
     totalLong = Decimal()
     totalShort = Decimal()
+    brokerInterestAccrualsComponent = Decimal()
+    brokerCashComponent = Decimal()
+    cfdUnrealizedPl = Decimal()
 
-
+    
 class CashReportCurrency(Schema, AccountMixin):
     """ Wrapped in <CashReport> """
     currency = OneOf(*CURRENCY_CODES)


### PR DESCRIPTION
`client.py`:
Fixed missing `token` and `query_id` in `requests_get_timeout`, and the calls from `send_request` and `get_statement`.

`schemata.py`:
Added missing fields to `EquitySummaryByReportDateInBase` and `TradeConfirmation`.