### PR TITLE
Update test_types.py

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1038,7 +1038,8 @@ class OpenDividendAccrualTestCase(unittest.TestCase):
         ('<OpenDividendAccrual accountId="U123456" acctAlias="ibflex test" model="" '
          'currency="USD" fxRateToBase="1" assetCategory="STK" symbol="CASH" '
          'description="META FINANCIAL GROUP INC" conid="3655441" securityID="" '
-         'securityIDType="" cusip="" isin="" underlyingConid="" underlyingSymbol="" '
+         'securityIDType="" cusip="" isin="" listingExchange="NYSE" underlyingConid="" '
+         'underlyingSymbol="" underlyingSecurityID="" underlyingListingExchange="" '
          'issuer="" multiplier="1" strike="" expiry="" putCall="" '
          'principalAdjustFactor="" exDate="2011-12-08" payDate="2012-01-01" '
          'quantity="25383" tax="0" fee="0" grossRate="0.13" grossAmount="3299.79" '
@@ -1061,8 +1062,11 @@ class OpenDividendAccrualTestCase(unittest.TestCase):
         self.assertEqual(instance.securityIDType, None)
         self.assertEqual(instance.cusip, None)
         self.assertEqual(instance.isin, None)
+        self.assertEqual(instance.listingExchange, "NYSE")
         self.assertEqual(instance.underlyingConid, None)
         self.assertEqual(instance.underlyingSymbol, None)
+        self.assertEqual(instance.underlyingSecurityID, None)
+        self.assertEqual(instance.underlyingListingExchange, None)
         self.assertEqual(instance.issuer, None)
         self.assertEqual(instance.multiplier, decimal.Decimal("1"))
         self.assertEqual(instance.strike, None)


### PR DESCRIPTION
Test modified to include 3 new fields: listingExchange, underlyingSecurityID, underlyingListingExchange

Chrisopher, and one more thing here. I updated the test case to include 3 new fields. But it seems test should be expanded somehow. Parser crashed when it had faced this 3 new fields in my report. But when I added it to the text in `data = ET.fromstring()` nothing was wrong, test passed. So, I added fields to `testParse()` as well to keep it actual but test case won't fail if XML will have some extra-fields that are not covered by test-case.