### PR TITLE
extend Trade and SecurityInfo types with new fields

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -891,6 +891,7 @@ class Trade(FlexElement):
     sedol: Optional[str] = None
     whenRealized: Optional[datetime.datetime] = None
     whenReopened: Optional[datetime.datetime] = None
+    accruedInt: Optional[Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -1724,6 +1725,7 @@ class SecurityInfo(FlexElement):
     principalAdjustFactor: Optional[decimal.Decimal] = None
     code: Tuple[enums.Code, ...] = ()
     currency: Optional[str] = None
+    settlementPolicyMethod: Optional[str] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Added 2 new fields that are presented in flex report by default.