### PR TITLE
Field levelOfDetail was added to CashTransaction

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -1612,6 +1612,7 @@ class CashTransaction(FlexElement):
     settleDate: Optional[datetime.date] = None
     acctAlias: Optional[str] = None
     model: Optional[str] = None
+    levelOfDetail: Optional[str] = None 
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Hi Christopher,

One of my users faced this field in CashTransaction so I added it here.
Unfortunately I can't add a test as I don't have a copy of transaction itself (but I'm sure that this patch helped to resolve the problem). 
I assume this field has the same meaning as for Trade - so I may copy test from Trade from CashTransaction if you wish, but I think it is safe to accept this pull request without test update.

Vlad