### PR TITLE
Adding MULTIPLE order type

### DIFF
--- a/ibflex/enums.py
+++ b/ibflex/enums.py
@@ -148,6 +148,9 @@ class OrderType(enum.Enum):
     LIMIT = "LMT"
     MARKET = "MKT"
     MARKETONCLOSE = "MOC"
+    # MULTIPLE is not an actual IB order type. It is a catch-all value to use when an Order has an orderType like "LMT;MKT".
+    # This way OrderType can remian a enum and not be a Tuple.
+    MULTIPLE = "MULTIPLE"
 
 
 @enum.unique

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -346,6 +346,9 @@ def convert_enum(Type, value):
     #  Work around old versions of values; convert to the new format
     if Type is enums.CashAction and value == "Deposits/Withdrawals":
         value = "Deposits & Withdrawals"
+    #  Work around for Orders with orderType like "LMT;MKT" -> "MULTIPLE"
+    if Type is enums.OrderType and ';' in value:
+        value = "MULTIPLE"
     elif Type is enums.TransferType and value == "ACAT":
         value = "ACATS"
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1523,7 +1523,7 @@ class TradesOrderTestCase(unittest.TestCase):
     'origTradeDate="" origTradeID="" origOrderID="" clearingFirmID="" transactionID="" ibExecID="" brokerageOrderID="" '
     'orderReference="" volatilityOrderLink="" exchOrderId="" extExecID="" orderTime="2021-02-03 10:01:50" openDateTime="" '
     'holdingPeriodDateTime="" whenRealized="" whenReopened="" levelOfDetail="ORDER" changeInPrice="" changeInQuantity="" '
-    'orderType="LMT" traderID="" isAPIOrder="" accruedInt="0" />'))
+    'orderType="LMT;MKT" traderID="" isAPIOrder="" accruedInt="0" />'))
 
     def testParse(self):
         instance = parser.parse_data_element(self.data)
@@ -1597,7 +1597,7 @@ class TradesOrderTestCase(unittest.TestCase):
         self.assertEqual(instance.levelOfDetail, "ORDER")
         self.assertEqual(instance.changeInPrice, None)
         self.assertEqual(instance.changeInQuantity, None)
-        self.assertEqual(instance.orderType, enums.OrderType.LIMIT)
+        self.assertEqual(instance.orderType, enums.OrderType.MULTIPLE)
         self.assertEqual(instance.traderID, None)
         self.assertEqual(instance.isAPIOrder, None)
         self.assertEqual(instance.accruedInt, decimal.Decimal("0"))


### PR DESCRIPTION
I have an Order from last year that shows one execution as LMT and one execution as MKT, so when I get a flex report at the Order level, the orderType shows as "LMT;MKT". I think it may have been caused by entering a Market to Limit order, but I'm not sure.
https://interactivebrokers.github.io/tws-api/basic_orders.html#markettolimit

In any case, ibflex was throwing an exception, and this was my fix.

I figured that making orderType a Tuple would be a breaking change for most applications, and not very useful overall, so I added a workaround that interprets a list of order types as MULTIPLE.
