### PR TITLE
Adding max_tries optional argument to download

### DIFF
--- a/ibflex/client.py
+++ b/ibflex/client.py
@@ -65,6 +65,12 @@ class BadResponseError(IbflexClientError):
     def __init__(self, response: requests.Response):
         self.response = response
         super(BadResponseError, self).__init__(response.content)
+        
+
+class StatementGenerationTimeout(IbflexClientError):
+    """ Exception raised when the Flex server says it is generating the response,
+        but does not finish generating the statement in a timely fashion.
+    """
 
 
 class ResponseCodeError(IbflexClientError):
@@ -97,7 +103,7 @@ class StatementError:
 ###############################################################################
 # FUNCTIONS
 ###############################################################################
-def download(token: str, query_id: str) -> bytes:
+def download(token: str, query_id: str, max_tries: Optional[int] = 5) -> bytes:
     """2-step FlexQueryReport download process.
 
     Args:
@@ -107,14 +113,20 @@ def download(token: str, query_id: str) -> bytes:
     """
     stmt_access = request_statement(token, query_id)
     status = 0
+    tries = 0
     while status is not True:
         time.sleep(status)
+        tries += 1
         response = submit_request(
             url=stmt_access.Url or STMT_URL,
             token=token,
             query=stmt_access.ReferenceCode,
         )
         status = check_statement_response(response)
+        if tries > max_tries:
+            raise StatementGenerationTimeout(
+                "Exceeded max number of tries while attempting download"
+            )
     return response.content
 
 


### PR DESCRIPTION
This adds an optional max_tries parameter to the download function that will throw StatementGenerationTimeout if exceeded.

Sometimes, especially on the weekend, the flex server responds with ("1019", "Statement generation in progress. Please try again shortly.") but it doesn't finish in any reasonable amount of time, and just keeps responding with 1019.

I suspect that their API server is up, but some other server the Flex service depends on is down. Having a max_tries makes it easy for an application to bail on the download if desired.