### PR TITLE
Added additional fields to class `TradeTestCase`

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -540,7 +540,8 @@ class TradeTestCase(unittest.TestCase):
          'exchOrderId="N/A" extExecID="N/A" orderTime="" openDateTime="" '
          'holdingPeriodDateTime="" whenRealized="" whenReopened="" '
          'levelOfDetail="EXECUTION" changeInPrice="0" changeInQuantity="0" '
-         'orderType="" traderID="" isAPIOrder="N" />')
+         'orderType="" traderID="" isAPIOrder="N" accruedInt="0" serialNumber="" '
+         'deliveryType="" commodityType="" fineness="0.0" weight="0.0 ()" />')
     )
 
     def testParse(self):
@@ -614,6 +615,12 @@ class TradeTestCase(unittest.TestCase):
         self.assertEqual(instance.orderType, None)
         self.assertEqual(instance.traderID, None)
         self.assertEqual(instance.isAPIOrder, False)
+        self.assertEqual(instance.accruedInt, decimal.Decimal("0"))
+        self.assertEqual(instance.serialNumber, None)
+        self.assertEqual(instance.deliveryType, None)
+        self.assertEqual(instance.commodityType, None)
+        self.assertEqual(instance.fineness, decimal.Decimal("0"))
+        self.assertEqual(instance.weight, "0.0 ()")
 
 
 class OptionEAETestCase(unittest.TestCase):


### PR DESCRIPTION
Added the following additional fields: accruedInt, serialNumber, deliveryType, commodityType, fineness, weight.
Based on example:
```
<Trade accountId="XXXXXX" acctAlias="" model="" currency="USD" fxRateToBase="1" assetCategory="STK" symbol="ALK" description="ALASKA AIR GROUP INC" conid="4352" securityID="US0116591092" securityIDType="ISIN" cusip="011659109" isin="US0116591092" listingExchange="NYSE" underlyingConid="" underlyingSymbol="" underlyingSecurityID="" underlyingListingExchange="" issuer="" multiplier="1" strike="" expiry="" tradeID="3608520076" putCall="" reportDate="20210312" principalAdjustFactor="" dateTime="20210312,133059" tradeDate="20210312" settleDateTarget="20210316" transactionType="ExchTrade" exchange="IBKRATS" quantity="0.3088" tradePrice="68.41" tradeMoney="21.125008" proceeds="-21.125008" taxes="0" ibCommission="-0.21125008" ibCommissionCurrency="USD" netCash="-21.33625808" closePrice="68.02" openCloseIndicator="O" notes="FP;P" cost="21.33625808" fifoPnlRealized="0" fxPnl="0" mtmPnl="-0.1204" origTradePrice="0" origTradeDate="" origTradeID="" origOrderID="0" clearingFirmID="" transactionID="15738557515" buySell="BUY" ibOrderID="1807825233" ibExecID="000102df.604bd43a.01.01" brokerageOrderID="0030c27b.0000ebaf.604b5ec3.0001" orderReference="" volatilityOrderLink="" exchOrderId="N/A" extExecID="0030c27b.00018c81.609ee3f4.0001" orderTime="20210312,133059" openDateTime="" holdingPeriodDateTime="" whenRealized="" whenReopened="" levelOfDetail="EXECUTION" changeInPrice="0" changeInQuantity="0" orderType="LMT" traderID="" isAPIOrder="N" accruedInt="0" serialNumber="" deliveryType="" commodityType="" fineness="0.0" weight="0.0 ()" />
```