### PR TITLE
Added Paxos attributes to class CashReportCurrency

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -91,7 +91,6 @@ __all__ = [
     "Order"
 ]
 
-
 import datetime
 import decimal
 from dataclasses import dataclass
@@ -542,12 +541,14 @@ class CashReportCurrency(FlexElement):
     brokerFeesCom: Optional[decimal.Decimal] = None
     brokerFeesMTD: Optional[decimal.Decimal] = None
     brokerFeesYTD: Optional[decimal.Decimal] = None
+    brokerFeesPaxos: Optional[decimal.Decimal] = None
     brokerInterest: Optional[decimal.Decimal] = None
     brokerInterestSec: Optional[decimal.Decimal] = None
     brokerInterestCom: Optional[decimal.Decimal] = None
     bondInterest: Optional[decimal.Decimal] = None
     bondInterestSec: Optional[decimal.Decimal] = None
     bondInterestCom: Optional[decimal.Decimal] = None
+    bondInterestPaxos: Optional[decimal.Decimal] = None
     cashSettlingMtm: Optional[decimal.Decimal] = None
     cashSettlingMtmSec: Optional[decimal.Decimal] = None
     cashSettlingMtmCom: Optional[decimal.Decimal] = None
@@ -575,75 +576,106 @@ class CashReportCurrency(FlexElement):
     fxTranslationGainLoss: Optional[decimal.Decimal] = None
     fxTranslationGainLossSec: Optional[decimal.Decimal] = None
     fxTranslationGainLossCom: Optional[decimal.Decimal] = None
+    fxTranslationGainLossPaxos: Optional[decimal.Decimal] = None
     otherFees: Optional[decimal.Decimal] = None
     otherFeesSec: Optional[decimal.Decimal] = None
     otherFeesCom: Optional[decimal.Decimal] = None
     endingCash: Optional[decimal.Decimal] = None
     endingCashSec: Optional[decimal.Decimal] = None
     endingCashCom: Optional[decimal.Decimal] = None
+    endingCashPaxos: Optional[decimal.Decimal] = None
     endingSettledCash: Optional[decimal.Decimal] = None
     endingSettledCashSec: Optional[decimal.Decimal] = None
     endingSettledCashCom: Optional[decimal.Decimal] = None
+    endingSettledCashPaxos: Optional[decimal.Decimal] = None
     endingCashIBUKL: Optional[decimal.Decimal] = None
     clientFeesMTD: Optional[decimal.Decimal] = None
     clientFeesYTD: Optional[decimal.Decimal] = None
+    clientFeesPaxos: Optional[decimal.Decimal] = None
     commissionsMTD: Optional[decimal.Decimal] = None
     commissionsYTD: Optional[decimal.Decimal] = None
+    commissionsPaxos: Optional[decimal.Decimal] = None
     billableCommissionsMTD: Optional[decimal.Decimal] = None
     billableCommissionsYTD: Optional[decimal.Decimal] = None
+    billableCommissionsPaxos: Optional[decimal.Decimal] = None
     depositWithdrawalsMTD: Optional[decimal.Decimal] = None
     depositWithdrawalsYTD: Optional[decimal.Decimal] = None
+    depositWithdrawalsPaxos: Optional[decimal.Decimal] = None
     depositsMTD: Optional[decimal.Decimal] = None
     depositsYTD: Optional[decimal.Decimal] = None
+    depositsPaxos: Optional[decimal.Decimal] = None
     withdrawalsMTD: Optional[decimal.Decimal] = None
     withdrawalsYTD: Optional[decimal.Decimal] = None
+    withdrawalsPaxos: Optional[decimal.Decimal] = None
     accountTransfersMTD: Optional[decimal.Decimal] = None
     accountTransfersYTD: Optional[decimal.Decimal] = None
+    accountTransfersPaxos: Optional[decimal.Decimal] = None
     internalTransfersMTD: Optional[decimal.Decimal] = None
     internalTransfersYTD: Optional[decimal.Decimal] = None
+    internalTransfersPaxos: Optional[decimal.Decimal] = None
+    paxosTransfersPaxos: Optional[decimal.Decimal] = None
     excessFundSweep: Optional[decimal.Decimal] = None
     excessFundSweepSec: Optional[decimal.Decimal] = None
     excessFundSweepCom: Optional[decimal.Decimal] = None
     excessFundSweepMTD: Optional[decimal.Decimal] = None
     excessFundSweepYTD: Optional[decimal.Decimal] = None
+    excessFundSweepPaxos: Optional[decimal.Decimal] = None
     dividendsMTD: Optional[decimal.Decimal] = None
     dividendsYTD: Optional[decimal.Decimal] = None
+    dividendsPaxos: Optional[decimal.Decimal] = None
     insuredDepositInterestMTD: Optional[decimal.Decimal] = None
     insuredDepositInterestYTD: Optional[decimal.Decimal] = None
+    insuredDepositInteresPaxos: Optional[decimal.Decimal] = None
     brokerInterestMTD: Optional[decimal.Decimal] = None
     brokerInterestYTD: Optional[decimal.Decimal] = None
+    brokerInterestPaxos: Optional[decimal.Decimal] = None
     bondInterestMTD: Optional[decimal.Decimal] = None
     bondInterestYTD: Optional[decimal.Decimal] = None
     cashSettlingMtmMTD: Optional[decimal.Decimal] = None
     cashSettlingMtmYTD: Optional[decimal.Decimal] = None
+    cashSettlingMtmPaxos: Optional[decimal.Decimal] = None
     realizedVmMTD: Optional[decimal.Decimal] = None
     realizedVmYTD: Optional[decimal.Decimal] = None
+    realizedVmPaxos: Optional[decimal.Decimal] = None
     cfdChargesMTD: Optional[decimal.Decimal] = None
     cfdChargesYTD: Optional[decimal.Decimal] = None
+    cfdChargesPaxos: Optional[decimal.Decimal] = None
     netTradesSalesMTD: Optional[decimal.Decimal] = None
     netTradesSalesYTD: Optional[decimal.Decimal] = None
+    netTradesSalesPaxos: Optional[decimal.Decimal] = None
     advisorFeesMTD: Optional[decimal.Decimal] = None
     advisorFeesYTD: Optional[decimal.Decimal] = None
+    advisorFeePaxos: Optional[decimal.Decimal] = None
     feesReceivablesMTD: Optional[decimal.Decimal] = None
     feesReceivablesYTD: Optional[decimal.Decimal] = None
+    feesReceivablesPaxos: Optional[decimal.Decimal] = None
     netTradesPurchasesMTD: Optional[decimal.Decimal] = None
     netTradesPurchasesYTD: Optional[decimal.Decimal] = None
+    netTradesPurchasesPaxos: Optional[decimal.Decimal] = None
     paymentInLieuMTD: Optional[decimal.Decimal] = None
     paymentInLieuYTD: Optional[decimal.Decimal] = None
+    paymentInLieuPaxos: Optional[decimal.Decimal] = None
     transactionTaxMTD: Optional[decimal.Decimal] = None
     transactionTaxYTD: Optional[decimal.Decimal] = None
+    transactionTaxPaxos: Optional[decimal.Decimal] = None
     taxReceivablesMTD: Optional[decimal.Decimal] = None
     taxReceivablesYTD: Optional[decimal.Decimal] = None
+    taxReceivablesPaxos: Optional[decimal.Decimal] = None
     withholdingTaxMTD: Optional[decimal.Decimal] = None
     withholdingTaxYTD: Optional[decimal.Decimal] = None
+    withholdingTaxPaxos: Optional[decimal.Decimal] = None
     withholding871mMTD: Optional[decimal.Decimal] = None
     withholding871mYTD: Optional[decimal.Decimal] = None
+    withholding871mPaxos: Optional[decimal.Decimal] = None
     withholdingCollectedTaxMTD: Optional[decimal.Decimal] = None
     withholdingCollectedTaxYTD: Optional[decimal.Decimal] = None
+    withholdingCollectedTaxPaxos: Optional[decimal.Decimal] = None
     salesTaxMTD: Optional[decimal.Decimal] = None
     salesTaxYTD: Optional[decimal.Decimal] = None
+    salesTaxPaxos: Optional[decimal.Decimal] = None
     otherFeesMTD: Optional[decimal.Decimal] = None
     otherFeesYTD: Optional[decimal.Decimal] = None
+    otherFeesPaxos: Optional[decimal.Decimal] = None
     acctAlias: Optional[str] = None
     model: Optional[str] = None
     avgCreditBalance: Optional[decimal.Decimal] = None
@@ -655,15 +687,18 @@ class CashReportCurrency(FlexElement):
     linkingAdjustments: Optional[decimal.Decimal] = None
     linkingAdjustmentsSec: Optional[decimal.Decimal] = None
     linkingAdjustmentsCom: Optional[decimal.Decimal] = None
+    linkingAdjustmentsPaxos: Optional[decimal.Decimal] = None
     insuredDepositInterest: Optional[decimal.Decimal] = None
     insuredDepositInterestSec: Optional[decimal.Decimal] = None
     insuredDepositInterestCom: Optional[decimal.Decimal] = None
+    insuredDepositInterestPaxos: Optional[decimal.Decimal] = None
     realizedVm: Optional[decimal.Decimal] = None
     realizedVmSec: Optional[decimal.Decimal] = None
     realizedVmCom: Optional[decimal.Decimal] = None
     advisorFees: Optional[decimal.Decimal] = None
     advisorFeesSec: Optional[decimal.Decimal] = None
     advisorFeesCom: Optional[decimal.Decimal] = None
+    advisorFeesPaxos: Optional[decimal.Decimal] = None
     taxReceivables: Optional[decimal.Decimal] = None
     taxReceivablesSec: Optional[decimal.Decimal] = None
     taxReceivablesCom: Optional[decimal.Decimal] = None
@@ -679,38 +714,46 @@ class CashReportCurrency(FlexElement):
     other: Optional[decimal.Decimal] = None
     otherSec: Optional[decimal.Decimal] = None
     otherCom: Optional[decimal.Decimal] = None
+    otherPaxos: Optional[decimal.Decimal] = None
     levelOfDetail: Optional[str] = None
     debitCardActivity: Optional[decimal.Decimal] = None
     debitCardActivitySec: Optional[decimal.Decimal] = None
     debitCardActivityCom: Optional[decimal.Decimal] = None
     debitCardActivityMTD: Optional[decimal.Decimal] = None
     debitCardActivityYTD: Optional[decimal.Decimal] = None
+    debitCardActivityPaxos: Optional[decimal.Decimal] = None
     billPay: Optional[decimal.Decimal] = None
     billPaySec: Optional[decimal.Decimal] = None
     billPayCom: Optional[decimal.Decimal] = None
     billPayMTD: Optional[decimal.Decimal] = None
     billPayYTD: Optional[decimal.Decimal] = None
+    billPayPaxos: Optional[decimal.Decimal] = None
     realizedForexVm: Optional[decimal.Decimal] = None
     realizedForexVmSec: Optional[decimal.Decimal] = None
     realizedForexVmCom: Optional[decimal.Decimal] = None
     realizedForexVmMTD: Optional[decimal.Decimal] = None
     realizedForexVmYTD: Optional[decimal.Decimal] = None
+    realizedForexVmPaxos: Optional[decimal.Decimal] = None
     ipoSubscription: Optional[decimal.Decimal] = None
     ipoSubscriptionSec: Optional[decimal.Decimal] = None
     ipoSubscriptionCom: Optional[decimal.Decimal] = None
     ipoSubscriptionMTD: Optional[decimal.Decimal] = None
     ipoSubscriptionYTD: Optional[decimal.Decimal] = None
+    ipoSubscriptionPaxos: Optional[decimal.Decimal] = None
     billableSalesTax: Optional[decimal.Decimal] = None
     billableSalesTaxSec: Optional[decimal.Decimal] = None
     billableSalesTaxCom: Optional[decimal.Decimal] = None
     billableSalesTaxMTD: Optional[decimal.Decimal] = None
     billableSalesTaxYTD: Optional[decimal.Decimal] = None
+    billableSalesTaxPaxos: Optional[decimal.Decimal] = None
     commissionCreditsRedemption: Optional[decimal.Decimal] = None
     commissionCreditsRedemptionSec: Optional[decimal.Decimal] = None
     commissionCreditsRedemptionCom: Optional[decimal.Decimal] = None
     commissionCreditsRedemptionMTD: Optional[decimal.Decimal] = None
     commissionCreditsRedemptionYTD: Optional[decimal.Decimal] = None
+    commissionCreditsRedemptionPaxos: Optional[decimal.Decimal] = None
     referralFee: Optional[decimal.Decimal] = None
+    referralFeePaxos: Optional[decimal.Decimal] = None
     referralFeeSec: Optional[decimal.Decimal] = None
     referralFeeCom: Optional[decimal.Decimal] = None
     referralFeeMTD: Optional[decimal.Decimal] = None
@@ -720,11 +763,13 @@ class CashReportCurrency(FlexElement):
     carbonCreditsCom: Optional[decimal.Decimal] = None
     carbonCreditsMTD: Optional[decimal.Decimal] = None
     carbonCreditsYTD: Optional[decimal.Decimal] = None
+    carbonCreditsPaxos: Optional[decimal.Decimal] = None
     donations: Optional[decimal.Decimal] = None
     donationsSec: Optional[decimal.Decimal] = None
     donationsCom: Optional[decimal.Decimal] = None
     donationsMTD: Optional[decimal.Decimal] = None
     donationsYTD: Optional[decimal.Decimal] = None
+    donationsPaxos: Optional[decimal.Decimal] = None
     paxosTransfers: Optional[decimal.Decimal] = None
     paxosTransfersSec: Optional[decimal.Decimal] = None
     paxosTransfersCom: Optional[decimal.Decimal] = None
@@ -733,18 +778,23 @@ class CashReportCurrency(FlexElement):
     slbStartingCashCollateral: Optional[decimal.Decimal] = None
     slbStartingCashCollateralSec: Optional[decimal.Decimal] = None
     slbStartingCashCollateralCom: Optional[decimal.Decimal] = None
+    slbStartingCashCollateralPaxos: Optional[decimal.Decimal] = None
     slbNetSecuritiesLentActivity: Optional[decimal.Decimal] = None
     slbNetSecuritiesLentActivityCom: Optional[decimal.Decimal] = None
     slbNetSecuritiesLentActivitySec: Optional[decimal.Decimal] = None
-    slbEndingCashCollateral:    Optional[decimal.Decimal] = None
+    slbNetSecuritiesLentActivityPaxos: Optional[decimal.Decimal] = None
+    slbEndingCashCollateral: Optional[decimal.Decimal] = None
     slbEndingCashCollateralSec: Optional[decimal.Decimal] = None
     slbEndingCashCollateralCom: Optional[decimal.Decimal] = None
+    slbEndingCashCollateralPaxos: Optional[decimal.Decimal] = None
     slbNetCash: Optional[decimal.Decimal] = None
     slbNetCashSec: Optional[decimal.Decimal] = None
     slbNetCashCom: Optional[decimal.Decimal] = None
-    slbNetSettledCash:  Optional[decimal.Decimal] = None
+    slbNetCashPaxos: Optional[decimal.Decimal] = None
+    slbNetSettledCash: Optional[decimal.Decimal] = None
     slbNetSettledCashSec: Optional[decimal.Decimal] = None
     slbNetSettledCashCom: Optional[decimal.Decimal] = None
+    slbNetSettledCashPaxos: Optional[decimal.Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -997,6 +1047,7 @@ class Trade(FlexElement):
     relatedTradeID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
 
+
 @dataclass(frozen=True)
 class Lot(FlexElement):
     """ Wrapped in <Trades> """
@@ -1202,6 +1253,7 @@ class SymbolSummary(FlexElement):
     allocatedTo: Optional[str] = None
     accruedInt: Optional[decimal.Decimal] = None
 
+
 @dataclass(frozen=True)
 class AssetSummary(FlexElement):
     """ Wrapped in <TradeConfirms> """
@@ -1300,6 +1352,7 @@ class AssetSummary(FlexElement):
     commodityType: Optional[str] = None
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
+
 
 @dataclass(frozen=True)
 class Order(FlexElement):
@@ -1493,6 +1546,7 @@ class TradeConfirm(FlexElement):
     accruedInt: Optional[decimal.Decimal] = None
     relatedTradeID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
+
 
 @dataclass(frozen=True)
 class OptionEAE(FlexElement):
@@ -1989,7 +2043,7 @@ class CashTransaction(FlexElement):
     clientReference: Optional[str] = None
     settleDate: Optional[datetime.date] = None
     acctAlias: Optional[str] = None
-    actionID:   Optional[str] = None
+    actionID: Optional[str] = None
     model: Optional[str] = None
     levelOfDetail: Optional[str] = None
     serialNumber: Optional[str] = None

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -507,6 +507,7 @@ class CashReportCurrency(FlexElement):
     fromDate: Optional[datetime.date] = None
     toDate: Optional[datetime.date] = None
     startingCash: Optional[decimal.Decimal] = None
+    startingCashPaxos: Optional[decimal.Decimal] = None
     startingCashSec: Optional[decimal.Decimal] = None
     startingCashCom: Optional[decimal.Decimal] = None
     clientFees: Optional[decimal.Decimal] = None

--- a/ibflex/enums.py
+++ b/ibflex/enums.py
@@ -32,7 +32,7 @@ import typing
 
 
 @enum.unique
-class CashAction(enum.Enum):
+class CashAction(str, enum.Enum):
     DEPOSITWITHDRAW = "Deposits & Withdrawals"
     BROKERINTPAID = "Broker Interest Paid"
     BROKERINTRCVD = "Broker Interest Received"
@@ -46,67 +46,67 @@ class CashAction(enum.Enum):
 
 
 @enum.unique
-class Code(enum.Enum):
+class Code(str, enum.Enum):
     """Used for both `code` and `notes` attributes.
     """
     ASSIGNMENT = "A"
-    AUTOEXERCISE = "AEx"          # Automatic exercise for dividend-related recommendation
-    ADJUSTMENT = "Adj"            # Adjustment
-    ALLOCATION = "Al"             # Allocation
-    AWAY = "Aw"                   # Away Trade
-    BUYIN = "B"                   # Automatic Buy-in
-    BORROW = "Bo"                 # Direct Borrow
-    CLOSING = "C"                 # Closing Trade
-    CASHDELIVERY = "CD"           # Cash Delivery
-    COMPLEX = "CP"                # Complex Position
-    CANCEL = "Ca"                 # Cancelled
-    CORRECT = "Co"                # Corrected Trade
-    CROSSING = "Cx"               # Part or all of this transaction was a Crossing executed as dual agent by IB for two IB customers
-    DUAL = "D"                    # IB acted as Dual Agent, UNIQUE TO TRADE CONFIRM REPORT
-    ETF = "ETF"                   # ETF Creation/Redemption
-    EXPIRED = "Ep"                # Resulted from an Expired Position
-    EXERCISE = "Ex"               # Exercise
-    GUARANTEED = "G"              # Trade in Guaranteed Account Segment
-    HIGHESTCOST = "HC"            # Highest Cost tax lot-matching method
-    HFINVESTMENT = "HFI"          # Investment Transferred to Hedge Fund
-    HFREDEMPTION = "HFR"          # Redemption from Hedge Fund
-    INTERNAL = "I"                # Internal Transfer
-    AFFILIATE = "IA"              # This transaction was executed against an IB affiliate
-    INVESTOR = "INV"              # Investment Transfer from Investor
-    MARGINLOW = "L"               # Ordered by IB (Margin Violation)
-    WASHSALE = "LD"               # Adjusted by Loss Disallowed from Wash Sale
-    LIFO = "LI"                   # Last In, First Out (LIFO) tax lot-matching method
-    LTCG = "LT"                   # Long-term P/L
-    LOAN = "Lo"                   # Direct Loan
-    MANUAL = "M"                  # Entered manually by IB
-    MANUALEXERCISE = "MEx"        # Manual exercise for dividend-related recommendation
-    MAXLOSS = "ML"                # Maximize Losses tax basis election
-    MAXLTCG = "MLG"               # Maximize Long-Term Gain tax lot-matching method
-    MINLTCG = "MLL"               # Maximize Long-Term Loss tax lot-matching method
-    MAXSTCG = "MSG"               # Maximize Short-Term Gain tax lot-matching method
-    MINSTCG = "MSL"               # Maximize Short-Term Loss tax lot-matching method
-    OPENING = "O"                 # Opening Trade
-    PARTIAL = "P"                 # Partial Execution
+    AUTOEXERCISE = "AEx"  # Automatic exercise for dividend-related recommendation
+    ADJUSTMENT = "Adj"  # Adjustment
+    ALLOCATION = "Al"  # Allocation
+    AWAY = "Aw"  # Away Trade
+    BUYIN = "B"  # Automatic Buy-in
+    BORROW = "Bo"  # Direct Borrow
+    CLOSING = "C"  # Closing Trade
+    CASHDELIVERY = "CD"  # Cash Delivery
+    COMPLEX = "CP"  # Complex Position
+    CANCEL = "Ca"  # Cancelled
+    CORRECT = "Co"  # Corrected Trade
+    CROSSING = "Cx"  # Part or all of this transaction was a Crossing executed as dual agent by IB for two IB customers
+    DUAL = "D"  # IB acted as Dual Agent, UNIQUE TO TRADE CONFIRM REPORT
+    ETF = "ETF"  # ETF Creation/Redemption
+    EXPIRED = "Ep"  # Resulted from an Expired Position
+    EXERCISE = "Ex"  # Exercise
+    GUARANTEED = "G"  # Trade in Guaranteed Account Segment
+    HIGHESTCOST = "HC"  # Highest Cost tax lot-matching method
+    HFINVESTMENT = "HFI"  # Investment Transferred to Hedge Fund
+    HFREDEMPTION = "HFR"  # Redemption from Hedge Fund
+    INTERNAL = "I"  # Internal Transfer
+    AFFILIATE = "IA"  # This transaction was executed against an IB affiliate
+    INVESTOR = "INV"  # Investment Transfer from Investor
+    MARGINLOW = "L"  # Ordered by IB (Margin Violation)
+    WASHSALE = "LD"  # Adjusted by Loss Disallowed from Wash Sale
+    LIFO = "LI"  # Last In, First Out (LIFO) tax lot-matching method
+    LTCG = "LT"  # Long-term P/L
+    LOAN = "Lo"  # Direct Loan
+    MANUAL = "M"  # Entered manually by IB
+    MANUALEXERCISE = "MEx"  # Manual exercise for dividend-related recommendation
+    MAXLOSS = "ML"  # Maximize Losses tax basis election
+    MAXLTCG = "MLG"  # Maximize Long-Term Gain tax lot-matching method
+    MINLTCG = "MLL"  # Maximize Long-Term Loss tax lot-matching method
+    MAXSTCG = "MSG"  # Maximize Short-Term Gain tax lot-matching method
+    MINSTCG = "MSL"  # Maximize Short-Term Loss tax lot-matching method
+    OPENING = "O"  # Opening Trade
+    PARTIAL = "P"  # Partial Execution
     FRACRISKLESSPRINCIPAL = "RP"  # IB acted as riskless principal for the fractional share portion of this trade
-    FRACPRINCIPAL = "FP"          # IB acted as principal for the fractional share portion of this trade
-    PRICEIMPROVEMENT = "PI"       # Price Improvement
-    POSTACCRUAL = "Po"            # Interest or Dividend Accrual Posting
-    PRINCIPAL = "Pr"              # Part or all of this transaction was executed by the Exchange as a Crossing by IB against an IB affiliate and is therefore classified as a Principal and not an agency trade
-    REINVESTMENT = "R"            # Dividend Reinvestment
-    REDEMPTION = "RED"            # Redemption to Investor
-    REVERSE = "Re"                # Interest or Dividend Accrual Reversal
-    REIMBURSEMENT = "Ri"          # Reimbursement
-    SOLICITEDIB = "SI"            # This order was solicited by Interactive Brokers
-    SPECIFICLOT = "SL"            # Specific Lot tax lot-matching method
-    SOLICITEDOTHER = "SO"         # This order was marked as solicited by your Introducing Broker
-    SHORTENEDSETTLEMENT = "SS"    # Customer designated this trade for shortened settlement and so is subject to execution at prices above the prevailing market
-    STCG = "ST"                   # Short-term P/L
-    STOCKYIELD = "SY"             # Positions that may be eligible for Stock Yield.
-    TRANSFER = "T"                # Transfer
+    FRACPRINCIPAL = "FP"  # IB acted as principal for the fractional share portion of this trade
+    PRICEIMPROVEMENT = "PI"  # Price Improvement
+    POSTACCRUAL = "Po"  # Interest or Dividend Accrual Posting
+    PRINCIPAL = "Pr"  # Part or all of this transaction was executed by the Exchange as a Crossing by IB against an IB affiliate and is therefore classified as a Principal and not an agency trade
+    REINVESTMENT = "R"  # Dividend Reinvestment
+    REDEMPTION = "RED"  # Redemption to Investor
+    REVERSE = "Re"  # Interest or Dividend Accrual Reversal
+    REIMBURSEMENT = "Ri"  # Reimbursement
+    SOLICITEDIB = "SI"  # This order was solicited by Interactive Brokers
+    SPECIFICLOT = "SL"  # Specific Lot tax lot-matching method
+    SOLICITEDOTHER = "SO"  # This order was marked as solicited by your Introducing Broker
+    SHORTENEDSETTLEMENT = "SS"  # Customer designated this trade for shortened settlement and so is subject to execution at prices above the prevailing market
+    STCG = "ST"  # Short-term P/L
+    STOCKYIELD = "SY"  # Positions that may be eligible for Stock Yield.
+    TRANSFER = "T"  # Transfer
 
 
 @enum.unique
-class AssetClass(enum.Enum):
+class AssetClass(str, enum.Enum):
     CASH = "CASH"
     BILL = "BILL"
     BOND = "BOND"
@@ -126,7 +126,7 @@ class AssetClass(enum.Enum):
 
 
 @enum.unique
-class TradeType(enum.Enum):
+class TradeType(str, enum.Enum):
     EXCHTRADE = "ExchTrade"
     TRADECANCEL = "TradeCancel"
     FRACSHARE = "FracShare"
@@ -137,7 +137,7 @@ class TradeType(enum.Enum):
 
 
 @enum.unique
-class BuySell(enum.Enum):
+class BuySell(str, enum.Enum):
     BUY = "BUY"
     CANCELBUY = "BUY (Ca.)"
     SELL = "SELL"
@@ -145,7 +145,7 @@ class BuySell(enum.Enum):
 
 
 @enum.unique
-class OpenClose(enum.Enum):
+class OpenClose(str, enum.Enum):
     OPEN = "O"
     CLOSE = "C"
     OPENCLOSE = "C;O"
@@ -153,7 +153,7 @@ class OpenClose(enum.Enum):
 
 
 @enum.unique
-class OrderType(enum.Enum):
+class OrderType(str, enum.Enum):
     LIMIT = "LMT"
     MARKET = "MKT"
     STOP = "STP"
@@ -166,7 +166,7 @@ class OrderType(enum.Enum):
 
 
 @enum.unique
-class Reorg(enum.Enum):
+class Reorg(str, enum.Enum):
     BONDCONVERSION = "BC"
     BONDMATURITY = "BM"
     CONTRACTSOULTE = "CA"
@@ -202,7 +202,7 @@ class Reorg(enum.Enum):
 
 
 @enum.unique
-class OptionAction(enum.Enum):
+class OptionAction(str, enum.Enum):
     ASSIGN = "Assignment"
     EXERCISE = "Exercise"
     EXPIRE = "Expiration"
@@ -212,37 +212,37 @@ class OptionAction(enum.Enum):
 
 
 @enum.unique
-class LongShort(enum.Enum):
+class LongShort(str, enum.Enum):
     LONG = "Long"
     SHORT = "Short"
 
 
 @enum.unique
-class ToFrom(enum.Enum):
+class ToFrom(str, enum.Enum):
     TO = "To"
     FROM = "From"
 
 
 @enum.unique
-class TransferType(enum.Enum):
+class TransferType(str, enum.Enum):
     INTERNAL = "INTERNAL"
     ACATS = "ACATS"
 
 
 @enum.unique
-class InOut(enum.Enum):
+class InOut(str, enum.Enum):
     IN = "IN"
     OUT = "OUT"
 
 
 @enum.unique
-class DeliveredReceived(enum.Enum):
+class DeliveredReceived(str, enum.Enum):
     DELIVERED = "Delivered"
     RECEIVED = "Received"
 
 
 @enum.unique
-class PutCall(enum.Enum):
+class PutCall(str, enum.Enum):
     PUT = "P"
     CALL = "C"
 
@@ -265,7 +265,6 @@ ENUMS = [
     PutCall,
 ]
 """Used by ibflex.parser.ATTRIB_CONVERTERS"""
-
 
 EnumType = typing.Union[
     typing.Optional[CashAction],


### PR DESCRIPTION
- Parser was breaking due to Paxos fields not being present on the CashReportCurrency Class
- Added str as a superclass of Enums so that they can be serialized to JSON properly.