### PR TITLE
Added Missing fields for Trade and for CashReport

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -2091,6 +2091,7 @@ class CashTransaction(FlexElement):
     commodityType: Optional[str] = None
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
+    figi: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -802,7 +802,7 @@ class CashReportCurrency(FlexElement):
     slbNetSettledCash: Optional[decimal.Decimal] = None
     slbNetSettledCashSec: Optional[decimal.Decimal] = None
     slbNetSettledCashCom: Optional[decimal.Decimal] = None
-    
+    slbNetSettledCashPaxos: Optional[decimal.Decimal] = None
     
     
 @dataclass(frozen=True)

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -805,6 +805,7 @@ class CashReportCurrency(FlexElement):
     slbNetSettledCashPaxos: Optional[decimal.Decimal] = None
     
     
+    
 @dataclass(frozen=True)
 class StatementOfFundsLine(FlexElement):
     """ Wrapped in <StmtFunds> """

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -1057,6 +1057,7 @@ class Trade(FlexElement):
     relatedTransactionID: Optional[str] = None
     origTransactionID: Optional[str] = None
     subCategory: Optional[str] = None
+    figi: Optional[str] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
`slbNetSettledCashPaxos` for `CashReport`
`figi` for `CashTransaction`
`figi` for `Trade`
