### PR TITLE
Added actionID to CashTransaction

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -2093,6 +2093,7 @@ class CashTransaction(FlexElement):
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
     figi: Optional[str] = None
+    actionID: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -809,7 +809,8 @@ class CashTransactionTestCase(unittest.TestCase):
          'isin="ANN741081064" underlyingConid="" underlyingSymbol="" issuer="" '
          'multiplier="1" strike="" expiry="" putCall="" principalAdjustFactor="" '
          'dateTime="2015-10-06" amount="27800" type="Dividends" tradeID="" code="" '
-         'transactionID="5767420360" reportDate="2015-10-06" clientReference="" />')
+         'transactionID="5767420360" reportDate="2015-10-06" clientReference="" '
+         'actionID="222598649" />')
     )
 
     def testParse(self):
@@ -844,6 +845,7 @@ class CashTransactionTestCase(unittest.TestCase):
         self.assertEqual(instance.transactionID, "5767420360")
         self.assertEqual(instance.reportDate, datetime.date(2015,10, 6))
         self.assertEqual(instance.clientReference, None)
+        self.assertEqual(instance.actionID, "222598649")
 
 
 class DebitCardActivityTestCase(unittest.TestCase):


### PR DESCRIPTION
actionID can be used to match e.g. dividends with dividend tax transactions