### PR TITLE
Add GitHub Actions workflow for automated PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

This adds a GitHub Actions workflow that automatically publishes to PyPI when you create a release.

## Background

I needed ibflex for a project but the PyPI version (0.15, Jan 2021) is missing years of updates. Rather than just complain, I set up CI and published a fork as [`ibflex2`](https://pypi.org/project/ibflex2/) to unblock myself and others.

## This PR

Adds `.github/workflows/publish.yml` that:
- Triggers on GitHub release creation
- Builds the package using `python -m build`
- Publishes to PyPI using trusted publishing (no tokens needed)

## Setup Required

To use this, you'll need to:
1. Create a GitHub environment called `pypi` (Settings → Environments → New environment)
2. Configure "trusted publishing" on PyPI:
   - Go to https://pypi.org/manage/project/ibflex/settings/publishing/
   - Add a trusted publisher with:
     - Owner: `csingley`
     - Repository: `ibflex`
     - Workflow: `publish.yml`
     - Environment: `pypi`
3. Create a release and it will auto-publish

## If You'd Prefer Not To

No worries - `ibflex2` exists on PyPI for those who need current updates. If you do start publishing regular releases, I'm happy to deprecate the fork.

Closes #73