### PR TITLE
Add an opt-in method to enable tolerance against new attribibutes

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -2300,6 +2300,11 @@ class CorporateAction(FlexElement):
     commodityType: Optional[str] = None
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
+    figi: Optional[str] = None
+    issuerCountryCode: Optional[str] = None
+    costBasis: Optional[decimal.Decimal] = None
+    
+
 
 
 @dataclass(frozen=True)

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -479,6 +479,7 @@ class EquitySummaryByReportDateInBase(FlexElement):
     marginFinancingChargeAccrualsShort: Optional[decimal.Decimal] = None
     cryptoLong: Optional[decimal.Decimal] = None
     cryptoShort: Optional[decimal.Decimal] = None
+    liteSurchargeAccruals: Optional[decimal.Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -1146,7 +1147,7 @@ class Trade(FlexElement):
     subCategory: Optional[str] = None
     issuerCountryCode: Optional[str] = None
     rtn: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     positionActionID: Optional[str] = None
 
 
@@ -1299,7 +1300,7 @@ class Lot(FlexElement):
     issuerCountryCode: Optional[str] = None
     relatedTradeID: Optional[str] = None
     rtn: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     positionActionID: Optional[str] = None
 
 
@@ -1457,7 +1458,7 @@ class SymbolSummary(FlexElement):
     ibCommissionCurrency: Optional[str] = None
     ibExecID: Optional[str] = None
     ibOrderID: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     mtmPnl: Optional[decimal.Decimal] = None
     netCash: Optional[decimal.Decimal] = None
     netCashInBase: Optional[decimal.Decimal] = None
@@ -1583,7 +1584,7 @@ class AssetSummary(FlexElement):
     origTransactionID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
     rtn: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     positionActionID: Optional[str] = None
 
 
@@ -1687,7 +1688,7 @@ class Order(FlexElement):
     origTransactionID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
     rtn: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     serialNumber: Optional[str] = None
     deliveryType: Optional[str] = None
     commodityType: Optional[str] = None
@@ -1846,7 +1847,7 @@ class OptionEAE(FlexElement):
     origTransactionID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
     rtn: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     serialNumber: Optional[str] = None
     deliveryType: Optional[str] = None
     commodityType: Optional[str] = None
@@ -2540,7 +2541,7 @@ class SecurityInfo(FlexElement):
     origTransactionID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
     rtn: Optional[str] = None
-    initialInvestment: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[bool] = None
     serialNumber: Optional[str] = None
     deliveryType: Optional[str] = None
     commodityType: Optional[str] = None

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -1147,6 +1147,7 @@ class Trade(FlexElement):
     issuerCountryCode: Optional[str] = None
     rtn: Optional[str] = None
     initialInvestment: Optional[decimal.Decimal] = None
+    positionActionID: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -1299,6 +1300,7 @@ class Lot(FlexElement):
     relatedTradeID: Optional[str] = None
     rtn: Optional[str] = None
     initialInvestment: Optional[decimal.Decimal] = None
+    positionActionID: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -1439,31 +1441,40 @@ class SymbolSummary(FlexElement):
     relatedTradeID: Optional[str] = None
     origTransactionID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
-    ibCommission: Optional[decimal.Decimal] = None
-    ibCommissionCurrency: Optional[str] = None
-    netCash: Optional[decimal.Decimal] = None
-    netCashInBase: Optional[decimal.Decimal] = None
-    closePrice: Optional[decimal.Decimal] = None
-    openCloseIndicator: Optional[enums.OpenClose] = None
-    notes: Optional[str] = None
-    cost: Optional[decimal.Decimal] = None
-    fifoPnlRealized: Optional[decimal.Decimal] = None
-    mtmPnl: Optional[decimal.Decimal] = None               # PnL at the time of reportins
-    ibOrderID: Optional[str] = None
-    origOrderID: Optional[str] = None
-    rtn: Optional[str] = None
-    whenRealized: Optional[datetime.datetime] = None
-    whenReopened: Optional[datetime.datetime] = None
+    positionActionID: Optional[str] = None
     changeInPrice: Optional[decimal.Decimal] = None
     changeInQuantity: Optional[decimal.Decimal] = None
-    initialInvestment: Optional[decimal.Decimal] = None
-    serialNumber: Optional[str] = None
-    deliveryType: Optional[str] = None
+    closePrice: Optional[decimal.Decimal] = None
     commodityType: Optional[str] = None
+    cost: Optional[decimal.Decimal] = None
+    deliveryType: Optional[str] = None
+    exchOrderId: Optional[str] = None
+    extExecID: Optional[str] = None
+    fifoPnlRealized: Optional[decimal.Decimal] = None
     fineness: Optional[decimal.Decimal] = None
+    holdingPeriodDateTime: Optional[datetime.datetime] = None
+    ibCommission: Optional[decimal.Decimal] = None
+    ibCommissionCurrency: Optional[str] = None
+    ibExecID: Optional[str] = None
+    ibOrderID: Optional[str] = None
+    initialInvestment: Optional[decimal.Decimal] = None
+    mtmPnl: Optional[decimal.Decimal] = None
+    netCash: Optional[decimal.Decimal] = None
+    netCashInBase: Optional[decimal.Decimal] = None
+    notes: Optional[str] = None
+    openCloseIndicator: Optional[enums.OpenClose] = None
+    openDateTime: Optional[datetime.datetime] = None
+    origOrderID: Optional[str] = None
+    rtn: Optional[str] = None
+    serialNumber: Optional[str] = None
+    settleDateTarget: Optional[datetime.date] = None
+    taxes: Optional[decimal.Decimal] = None
+    tradeMoney: Optional[decimal.Decimal] = None
+    tradePrice: Optional[decimal.Decimal] = None
+    transactionID: Optional[str] = None
     weight: Optional[str] = None
-
-
+    whenRealized: Optional[datetime.datetime] = None
+    whenReopened: Optional[datetime.datetime] = None
 
 
 @dataclass(frozen=True)
@@ -1573,6 +1584,7 @@ class AssetSummary(FlexElement):
     relatedTransactionID: Optional[str] = None
     rtn: Optional[str] = None
     initialInvestment: Optional[decimal.Decimal] = None
+    positionActionID: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -1681,6 +1693,7 @@ class Order(FlexElement):
     commodityType: Optional[str] = None
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
+    positionActionID: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -709,6 +709,8 @@ class CashReportCurrency(FlexElement):
     salesTaxYTD: Optional[decimal.Decimal] = None
     salesTaxPaxos: Optional[decimal.Decimal] = None
     otherIncome: Optional[decimal.Decimal] = None
+    otherIncomeMTD: Optional[decimal.Decimal] = None
+    otherIncomeYTD: Optional[decimal.Decimal] = None
     otherIncomeSec: Optional[decimal.Decimal] = None
     otherIncomeCom: Optional[decimal.Decimal] = None
     otherFeesMTD: Optional[decimal.Decimal] = None
@@ -1397,7 +1399,9 @@ class SymbolSummary(FlexElement):
     dateTime: Optional[datetime.datetime] = None
     reportDate: Optional[datetime.date] = None
     settleDate: Optional[datetime.date] = None
+    taxes: Optional[decimal.Decimal] = None
     tradeDate: Optional[datetime.date] = None
+    tradePrice: Optional[decimal.Decimal] = None    
     exchange: Optional[str] = None
     buySell: Optional[enums.BuySell] = None
     quantity: Optional[decimal.Decimal] = None
@@ -1427,6 +1431,10 @@ class SymbolSummary(FlexElement):
     relatedTradeID: Optional[str] = None
     origTransactionID: Optional[str] = None
     relatedTransactionID: Optional[str] = None
+    ibCommission: Optional[decimal.Decimal] = None
+    ibCommissionCurrency: Optional[str] = None
+    netCash: Optional[decimal.Decimal] = None
+    netCashInBase: Optional[decimal.Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -2122,7 +2130,8 @@ class Transfer(FlexElement):
     commodityType: Optional[str] = None
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
-
+    figi: Optional[str] = None
+    settleDate: Optional[datetime.date] = None 
 
 @dataclass(frozen=True)
 class UnsettledTransfer(FlexElement):

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -2160,7 +2160,11 @@ class Transfer(FlexElement):
     fineness: Optional[decimal.Decimal] = None
     weight: Optional[str] = None
     figi: Optional[str] = None
-    settleDate: Optional[datetime.date] = None 
+    settleDate: Optional[datetime.date] = None
+    issuerCountryCode: Optional[str] = None
+    levelOfDetail: Optional[str] = None
+    positionInstructionID: Optional[str] = None
+    positionInstructionSetID: Optional[str] = None
 
 @dataclass(frozen=True)
 class UnsettledTransfer(FlexElement):

--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -1387,6 +1387,9 @@ class SymbolSummary(FlexElement):
     tradeID: Optional[str] = None
     orderID: Optional[decimal.Decimal] = None
     execID: Optional[str] = None
+    ibExecID: Optional[str] = None
+    extExecID: Optional[str] = None
+    exchOrderId: Optional[str] = None
     brokerageOrderID: Optional[str] = None
     orderReference: Optional[str] = None
     volatilityOrderLink: Optional[str] = None
@@ -1394,14 +1397,19 @@ class SymbolSummary(FlexElement):
     origTradePrice: Optional[decimal.Decimal] = None
     origTradeDate: Optional[datetime.date] = None
     origTradeID: Optional[str] = None
+    transactionID: Optional[str] = None
     #  Despite the name, `orderTime` actually contains date/time data.
     orderTime: Optional[datetime.datetime] = None
+    openDateTime: Optional[datetime.datetime] = None
+    holdingPeriodDateTime: Optional[datetime.datetime] = None
     dateTime: Optional[datetime.datetime] = None
     reportDate: Optional[datetime.date] = None
     settleDate: Optional[datetime.date] = None
+    settleDateTarget: Optional[datetime.date] = None        # expected date of ownership transfer
     taxes: Optional[decimal.Decimal] = None
     tradeDate: Optional[datetime.date] = None
     tradePrice: Optional[decimal.Decimal] = None    
+    tradeMoney: Optional[decimal.Decimal] = None            # TradeMoney = Proceeds + Fees + Commissions
     exchange: Optional[str] = None
     buySell: Optional[enums.BuySell] = None
     quantity: Optional[decimal.Decimal] = None
@@ -1435,6 +1443,27 @@ class SymbolSummary(FlexElement):
     ibCommissionCurrency: Optional[str] = None
     netCash: Optional[decimal.Decimal] = None
     netCashInBase: Optional[decimal.Decimal] = None
+    closePrice: Optional[decimal.Decimal] = None
+    openCloseIndicator: Optional[enums.OpenClose] = None
+    notes: Optional[str] = None
+    cost: Optional[decimal.Decimal] = None
+    fifoPnlRealized: Optional[decimal.Decimal] = None
+    mtmPnl: Optional[decimal.Decimal] = None               # PnL at the time of reportins
+    ibOrderID: Optional[str] = None
+    origOrderID: Optional[str] = None
+    rtn: Optional[str] = None
+    whenRealized: Optional[datetime.datetime] = None
+    whenReopened: Optional[datetime.datetime] = None
+    changeInPrice: Optional[decimal.Decimal] = None
+    changeInQuantity: Optional[decimal.Decimal] = None
+    initialInvestment: Optional[decimal.Decimal] = None
+    serialNumber: Optional[str] = None
+    deliveryType: Optional[str] = None
+    commodityType: Optional[str] = None
+    fineness: Optional[decimal.Decimal] = None
+    weight: Optional[str] = None
+
+
 
 
 @dataclass(frozen=True)

--- a/ibflex/__init__.py
+++ b/ibflex/__init__.py
@@ -4,6 +4,8 @@ from . import Types
 from .Types import *
 from . import parser
 from .parser import parse
+from .parser import enable_unknown_attribute_tolerance
+from .parser import disable_unknown_attribute_tolerance
 from . import utils
 from . import client
 

--- a/ibflex/client.py
+++ b/ibflex/client.py
@@ -136,8 +136,6 @@ def request_statement(
     """First part of the 2-step download process.
     """
     url = url or REQUEST_URL
-    ### AKE FIX
-    url = 'https://ndcdyn.interactivebrokers.com/portal.flexweb/api/v1/flexQuery'
     response = submit_request(url, token, query=query_id)
     stmt_access = parse_stmt_response(response)
     if isinstance(stmt_access, StatementError):

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -467,7 +467,7 @@ CURRENCY_CODES = ISO4217 + (
     "CNH",           # RMB traded in HK
     "BASE_SUMMARY",  # Fake currency code used in IB NAV/Performance reports
     "",              # Lot element allows blank currency ?!
-    "RUS",           # Appears with placeholder rate -1 in some list of rates. 
+    "RUS",           # Russian-related currency code used by IBKR
 )
 
 

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -332,8 +332,8 @@ def make_optional(func):
 
 convert_string = make_optional(make_converter(str, prep=utils.identity_func))
 convert_int = make_converter(int, prep=utils.identity_func)
-# IB sends "Y"/"N" for True/False
-convert_bool = make_converter(bool, prep=lambda x: {"Y": True, "N": False}[x])
+# IB sends "Y"/"N" or "Yes"/"No" for True/False
+convert_bool = make_converter(bool, prep=lambda x: {"Y": True, "N": False, "Yes": True, "No": False}[x])
 # IB sends numeric data with place delimiters (commas)
 convert_decimal = make_converter(
     decimal.Decimal,

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -192,18 +192,14 @@ def parse_data_element(
     #  that contain other data elements.
     contained_elements = {child.tag: parse_element(child) for child in elem}
     if contained_elements:
+        assert elem.tag in ("FlexQueryResponse", "FlexStatement")
         if _UNKNOWN_ATTRIBUTE_TOLERANCE:
-            if elem.tag in ("FlexQueryResponse", "FlexStatement"):
-                #  Filter out unknown or unparseable contained elements
-                contained_elements = {
-                    k: v for k, v in contained_elements.items()
-                    if k in known and v is not None
-                }
-                attrs.update(contained_elements)
-            #  else: tolerance is on, silently ignore children on other elements
-        else:
-            assert elem.tag in ("FlexQueryResponse", "FlexStatement")
-            attrs.update(contained_elements)
+            #  Filter out unknown or unparseable contained elements
+            contained_elements = {
+                k: v for k, v in contained_elements.items()
+                if k in known and v is not None
+            }
+        attrs.update(contained_elements)
 
     try:
         return Class(**attrs)

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -463,6 +463,7 @@ CURRENCY_CODES = ISO4217 + (
     "CNH",           # RMB traded in HK
     "BASE_SUMMARY",  # Fake currency code used in IB NAV/Performance reports
     "",              # Lot element allows blank currency ?!
+    "RUS",           # Appears with placeholder rate -1 in some list of rates. 
 )
 
 

--- a/ibflex/parser.py
+++ b/ibflex/parser.py
@@ -170,9 +170,11 @@ def parse_element_attr(
 #  INPUT VALUE PREP FUNCTIONS FOR DATA CONVERTERS
 #  These are just implementation details for converters and don't need testing.
 ###############################################################################
-def prep_date(value: str) -> Tuple[int, int, int]:
+def prep_date(value: str) -> Optional[Tuple[int, int, int]]:
     """Returns a tuple of (year, month, day).
     """
+    if value == "MULTI":
+        return None  # Summaries have MULTI as date value.
     date_format = DATE_FORMATS[len(value)][value.count('/')]
     return datetime.datetime.strptime(value, date_format).timetuple()[:3]
 
@@ -184,9 +186,11 @@ def prep_time(value: str) -> Tuple[int, int, int]:
     return datetime.datetime.strptime(value, time_format).timetuple()[3:6]
 
 
-def prep_datetime(value: str) -> Tuple[int, ...]:
+def prep_datetime(value: str) -> Optional[Tuple[int, ...]]:
     """Returns a tuple of (year, month, day, hour, minute, second).
     """
+    if value == "MULTI":
+        return None  # Summaries have MULTI as date value.
     #  HACK - some old data has ", " separator instead of ",".
     value = value.replace(", ", ",")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -333,9 +333,11 @@ class ConverterFunctionTestCase(unittest.TestCase):
             parser.convert_int("")
 
     def testConvertBool(self):
-        """ Legal boolean values are 'Y'/'N' """
+        """ Legal boolean values are 'Y'/'N' or 'Yes'/'No' """
         self.assertEqual(parser.convert_bool("Y"), True)
         self.assertEqual(parser.convert_bool("N"), False)
+        self.assertEqual(parser.convert_bool("Yes"), True)
+        self.assertEqual(parser.convert_bool("No"), False)
 
         #  Empty string raises FlexParserError.
         with self.assertRaises(parser.FlexParserError):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1985,5 +1985,49 @@ class OptionEAEBuyTestCase(unittest.TestCase):
         self.assertEqual(instance.tradeID, None)
 
 
+class TradeInitialInvestmentTestCase(unittest.TestCase):
+    """Test case for Trade.initialInvestment as boolean field.
+    
+    Tests the fix for https://github.com/vroonhof/opensteuerauszug/issues/106
+    where initialInvestment="Yes" was causing parsing errors.
+    """
+    data = ET.fromstring(
+        ('<Trade accountId="U123456" currency="USD" assetCategory="STK" '
+         'symbol="TEST" initialInvestment="Yes" quantity="100" />')
+    )
+
+    def testParse(self):
+        instance = parser.parse_data_element(self.data)
+        self.assertIsInstance(instance, Types.Trade)
+        self.assertEqual(instance.accountId, "U123456")
+        self.assertEqual(instance.currency, "USD")
+        self.assertEqual(instance.assetCategory, enums.AssetClass.STOCK)
+        self.assertEqual(instance.symbol, "TEST")
+        self.assertEqual(instance.initialInvestment, True)
+        self.assertEqual(instance.quantity, decimal.Decimal("100"))
+
+
+class EquitySummaryLiteSurchargeAccrualsTestCase(unittest.TestCase):
+    """Test case for EquitySummaryByReportDateInBase.liteSurchargeAccruals field.
+    
+    Tests the fix for https://github.com/vroonhof/opensteuerauszug/issues/106
+    where liteSurchargeAccruals attribute was missing.
+    """
+    data = ET.fromstring(
+        ('<EquitySummaryByReportDateInBase accountId="U123456" '
+         'reportDate="2024-01-01" cash="1000.00" total="1000.00" '
+         'liteSurchargeAccruals="5.50" />')
+    )
+
+    def testParse(self):
+        instance = parser.parse_data_element(self.data)
+        self.assertIsInstance(instance, Types.EquitySummaryByReportDateInBase)
+        self.assertEqual(instance.accountId, "U123456")
+        self.assertEqual(instance.reportDate, datetime.date(2024, 1, 1))
+        self.assertEqual(instance.cash, decimal.Decimal("1000.00"))
+        self.assertEqual(instance.total, decimal.Decimal("1000.00"))
+        self.assertEqual(instance.liteSurchargeAccruals, decimal.Decimal("5.50"))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=3)


### PR DESCRIPTION
IBKR keeps adding new fields while still not providing a simple way to programmatically set the flexquery spec. This means a never ending rat race of adding new attributes. This PR adds an opt in method to ignore those for end users of applications using ibflex.

Coded by Opus 4.5 via Cursor. Reviewed by me.