### PR TITLE
Added SNAPMID order type to enums

### DIFF
--- a/ibflex/enums.py
+++ b/ibflex/enums.py
@@ -173,6 +173,7 @@ class OrderType(str, enum.Enum):
     REL = "REL"
     MIT = "MIT"
     LIT = "LIT"
+    SNAPMID = "SNAPMID"
 
 @enum.unique
 class Reorg(str, enum.Enum):


### PR DESCRIPTION
Simply added the SNAPMID order type to the enums.